### PR TITLE
Allow QuickCheck 2.5

### DIFF
--- a/dlist.cabal
+++ b/dlist.cabal
@@ -36,5 +36,5 @@ test-suite test
   build-depends:        dlist,
                         base,
                         Cabal,
-                        QuickCheck >= 2.6 && < 2.7
+                        QuickCheck >= 2.5 && < 2.7
 


### PR DESCRIPTION
This makes it a bit easier to do Stackage builds. I've confirmed that with QuickCheck 2.5.1.1, the test suite builds and runs without failure.
