### PR TITLE
Bump QuickCheck version to test with GHC HEAD

### DIFF
--- a/dlist.cabal
+++ b/dlist.cabal
@@ -42,5 +42,4 @@ test-suite test
   build-depends:        dlist,
                         base,
                         Cabal,
-                        QuickCheck >= 2.5 && < 2.8
-
+                        QuickCheck >= 2.7 && < 2.8


### PR DESCRIPTION
This is due to the AMP (Functor-Applicative-Monad Proposal) that makes
Applicative a superclass of Monad. QuickCheck 2.7.1 (or so) added the
Applicative instance for their Rose type.
