### PR TITLE
dlist.cabal: add missing OverloadedStrings module to tarball

### DIFF
--- a/dlist.cabal
+++ b/dlist.cabal
@@ -40,6 +40,7 @@ library
 test-suite test
   type:                 exitcode-stdio-1.0
   main-is:              Main.hs
+  other-modules:        OverloadedStrings
   hs-source-dirs:       tests
   build-depends:        dlist,
                         base,


### PR DESCRIPTION
testsuite on hackage package fails as:

  Preprocessing test suite 'test' for dlist-0.8.0.1...
  [1 of 1] Compiling Main             ( tests/Main.hs, dist/build/test/test-tmp/Main.dyn_o )

  tests/Main.hs:24:1: error:
    Failed to load interface for ‘OverloadedStrings’
    Use -v to see a list of the files searched for.

Change adds OverloadedStrings to .cabal file

Signed-off-by: Sergei Trofimovich <siarheit@google.com>