### PR TITLE
make Data.DList trustworthy

### DIFF
--- a/Data/DList.hs
+++ b/Data/DList.hs
@@ -5,6 +5,7 @@
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
+{-# LANGUAGE Trustworthy #-}
 #endif
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Safety of Data.DList is not inferred because of the use of GHC.Exts,
but the IsList class is safe to use, so the module can be trusted.