### PR TITLE
Fix bogus upper bound on `deepseq`

### DIFF
--- a/dlist.cabal
+++ b/dlist.cabal
@@ -32,7 +32,7 @@ source-repository head
 library
   build-depends:
                         base >= 4 && < 5,
-                        deepseq >= 1.1 && < 2
+                        deepseq >= 1.1 && < 1.5
   extensions:           CPP
   exposed-modules:      Data.DList
   ghc-options:          -Wall


### PR DESCRIPTION
Being the maintainer of `deepseq` I'm confident to say that an upper bound `deepseq < 2` makes no sense, given that `deepseq` follow the PVP, and therefore a `deepseq-1.5` release can be as breaking as a breaking change can be... just like the change from `deepseq-1.0` to `deepseq-1.1` was.