### PR TITLE
Change the time complexity of head from O(n) to O(1)

### DIFF
--- a/Data/DList.hs
+++ b/Data/DList.hs
@@ -200,7 +200,7 @@ list nill consit dl =
     [] -> nill
     (x : xs) -> consit x (fromList xs)
 
--- | /O(n)/. Return the head of the dlist
+-- | /O(1)/. Return the head of the dlist
 head :: DList a -> a
 head = list (error "Data.DList.head: empty dlist") const
 


### PR DESCRIPTION
This example seems to indicate that it's not necessary to build the full list:

    > Data.DList.head (pure 1 <> undefined)
    1