### PR TITLE
Implement toList directly in the Foldable instance

### DIFF
--- a/Data/DList.hs
+++ b/Data/DList.hs
@@ -325,6 +325,12 @@ instance Foldable DList where
   {-# INLINE foldr' #-}
 #endif
 
+-- CPP: toList added to Foldable in base-4.8.0.0
+#if MIN_VERSION_base(4,8,0)
+  toList = Data.DList.toList
+  {-# INLINE toList #-}
+#endif
+
 instance NFData a => NFData (DList a) where
   rnf = rnf . toList
   {-# INLINE rnf #-}


### PR DESCRIPTION
Currently, the `Foldable DList` instance relies on the default implementation of `toList`. However, this default implementation is somewhat indirect since it uses `foldr`. `toList` can be more directly implemented as `toList = Data.DList.toList`, which avoids the need for `foldr` entirely.