### PR TITLE
Fix DNonEmpty show instance

### DIFF
--- a/Data/DList/DNonEmpty/Internal.hs
+++ b/Data/DList/DNonEmpty/Internal.hs
@@ -394,7 +394,7 @@ instance Read a => Read (DNonEmpty a) where
 instance Show a => Show (DNonEmpty a) where
   showsPrec p dl =
     showParen (p > 10) $
-      showString "fromNonEmpty " . shows (toNonEmpty dl)
+      showString "fromNonEmpty " . showsPrec 11 (toNonEmpty dl)
 
 instance Functor DNonEmpty where
   {-# INLINE fmap #-}


### PR DESCRIPTION
# Previous behaviour

```haskell
λ> show $ fromNonEmpty [1, 2, 3]
"fromNonEmpty 1 :| [2,3]"
λ> read @(DNonEmpty Int) $ show $ fromNonEmpty [1, 2, 3]
fromNonEmpty *** Exception: Prelude.read: no parse

```

# New behaviour

```haskell
λ> show (fromNonEmpty [1, 2, 3 :: Int])
"fromNonEmpty (1 :| [2,3])"
λ> read @(DNonEmpty Int) $ show $ fromNonEmpty [1, 2, 3]
fromNonEmpty (1 :| [2,3])
```

Full disclosure: this change is ported directly from [dlist-nonempty](https://github.com/phadej/dlist-nonempty/blob/master/src/Data/DList/NonEmpty/Internal.hs#L174).