### PR TITLE
Use a better source-repository

### DIFF
--- a/dlist.cabal
+++ b/dlist.cabal
@@ -36,7 +36,7 @@ tested-with:            GHC==7.0.4
 
 source-repository head
   type:                 git
-  location:             git://github.com/spl/dlist.git
+  location:             https://github.com/spl/dlist.git
 
 flag Werror
   description:          Enable -Werror


### PR DESCRIPTION
* It works for people who don't have GitHub SSH credentials
* Suggested by @andreasabel in #109