### PR TITLE
test: Set nonzero exitcode when tests fail

### DIFF
--- a/tests/DListProperties.hs
+++ b/tests/DListProperties.hs
@@ -20,7 +20,7 @@
 --------------------------------------------------------------------------------
 
 -- | QuickCheck property tests for DList.
-module DListProperties (test) where
+module DListProperties (properties) where
 
 --------------------------------------------------------------------------------
 
@@ -183,6 +183,3 @@ properties =
     ("Semigroup stimes", property prop_Semigroup_stimes)
 #endif
   ]
-
-test :: IO ()
-test = quickCheckLabeledProperties properties

--- a/tests/DNonEmptyProperties.hs
+++ b/tests/DNonEmptyProperties.hs
@@ -59,7 +59,7 @@ prop_map :: (Int -> Int) -> NonEmpty Int -> Bool
 prop_map f = eqWith (NonEmpty.map f) (toNonEmpty . map f . fromNonEmpty)
 
 prop_show_read :: NonEmpty Int -> Bool
-prop_show_read = eqWith id (read . show)
+prop_show_read = eqWith id (read . show) . fromNonEmpty
 
 prop_read_show :: NonEmpty Int -> Bool
 prop_read_show x = eqWith id (show . f . read) $ "fromNonEmpty (" ++ show x ++ ")"

--- a/tests/DNonEmptyProperties.hs
+++ b/tests/DNonEmptyProperties.hs
@@ -8,7 +8,7 @@
 --------------------------------------------------------------------------------
 
 -- | QuickCheck property tests for DNonEmpty.
-module DNonEmptyProperties (test) where
+module DNonEmptyProperties (properties) where
 
 --------------------------------------------------------------------------------
 
@@ -104,6 +104,3 @@ properties =
     ("fromList", property prop_fromList),
     ("Semigroup <>", property prop_Semigroup_append)
   ]
-
-test :: IO ()
-test = quickCheckLabeledProperties properties

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,7 +27,6 @@ import System.Exit (exitFailure)
 
 main :: IO ()
 main = do
-  OverloadedStrings.test
   result <- quickCheckLabeledProperties $
     DListProperties.properties
 -- CPP: GHC >= 8 for DNonEmpty

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -34,4 +34,5 @@ main = do
 #if __GLASGOW_HASKELL__ >= 800
     ++ DNonEmptyProperties.properties
 #endif
+  OverloadedStrings.test
   unless (isSuccess result) exitFailure

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -30,7 +30,7 @@ main = do
   OverloadedStrings.test
   result <- quickCheckLabeledProperties $
     DListProperties.properties
-  -- CPP: GHC >= 8 for DNonEmpty
+-- CPP: GHC >= 8 for DNonEmpty
 #if __GLASGOW_HASKELL__ >= 800
     ++ DNonEmptyProperties.properties
 #endif

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -18,14 +18,20 @@ import qualified DListProperties
 import qualified DNonEmptyProperties
 #endif
 import qualified OverloadedStrings
+import QuickCheckUtil (quickCheckLabeledProperties)
+import Control.Monad (unless)
+import Test.QuickCheck (isSuccess)
+import System.Exit (exitFailure)
 
 --------------------------------------------------------------------------------
 
 main :: IO ()
 main = do
-  DListProperties.test
--- CPP: GHC >= 8 for DNonEmpty
-#if __GLASGOW_HASKELL__ >= 800
-  DNonEmptyProperties.test
-#endif
   OverloadedStrings.test
+  result <- quickCheckLabeledProperties $
+    DListProperties.properties
+  -- CPP: GHC >= 8 for DNonEmpty
+#if __GLASGOW_HASKELL__ >= 800
+    ++ DNonEmptyProperties.properties
+#endif
+  unless (isSuccess result) exitFailure

--- a/tests/QuickCheckUtil.hs
+++ b/tests/QuickCheckUtil.hs
@@ -37,8 +37,8 @@ eqOn c f g x = c x ==> f x == g x
 
 --------------------------------------------------------------------------------
 
-quickCheckLabeledProperties :: [(String, Property)] -> IO ()
-quickCheckLabeledProperties = quickCheck . conjoin . map (uncurry label)
+quickCheckLabeledProperties :: [(String, Property)] -> IO Result
+quickCheckLabeledProperties = quickCheckResult . conjoin . map (uncurry label)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
IMPORTANT: Branch is based on os/fix-read-after-show-test, so please merge https://github.com/spl/dlist/pull/117 **before** this.

* Create a single list of quickcheck properties
* Test the result of the quickcehck run
* Exit with appropriate status code

Previously, `cabal test` would print PASS and exit with exitcode 0, even when a test was failing.